### PR TITLE
Rockets actions: Implement rocket booking

### DIFF
--- a/src/components/Rocket.jsx
+++ b/src/components/Rocket.jsx
@@ -1,19 +1,36 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import '../styles/rocket.scss';
+import { reservedRocket } from '../redux/rockets/rocketsSlice';
 
 const Rocket = ({
-  name, description, image,
-}) => (
-  <li className="rocket">
-    <img src={image} alt="rockets" className="rocket-image" />
-    <div className="rocket-information">
-      <h3 className="Rocket-name">{name}</h3>
-      <p className="rocket-description">{description}</p>
-      <button type="button" className="reserve-button">Reserve Rocket</button>
-    </div>
-  </li>
-);
+  name, description, image, reserved, id,
+}) => {
+  const dispatch = useDispatch();
+  const handleClick = (id) => {
+    dispatch(reservedRocket(id));
+  };
+  return (
+    <li className="rocket">
+      <img src={image} alt="rockets" className="rocket-image" />
+      <div className="rocket-information">
+        <h3 className="Rocket-name">{name}</h3>
+        <p className="rocket-description">
+          {
+            reserved ? <span className="reservation-status">Reserved</span> : <span />
+          }
+          {description}
+        </p>
+        <button type="button" onClick={() => { handleClick(id); }} className="reserve-button">
+          {
+            reserved ? 'Cancel Reservation' : 'Reserve Rocket'
+          }
+        </button>
+      </div>
+    </li>
+  );
+};
 
 Rocket.propTypes = {
   name: PropTypes.oneOfType([
@@ -25,6 +42,12 @@ Rocket.propTypes = {
     PropTypes.number,
   ]).isRequired,
   image: PropTypes.string.isRequired,
+  reserved: PropTypes.bool.isRequired,
+  id: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]).isRequired,
+
 };
 
 export default Rocket;

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -6,7 +6,6 @@ import { getRockects } from '../redux/rockets/rocketsSlice';
 const Rockets = () => {
   const { rockets } = useSelector((store) => store.rockets);
   const dispatch = useDispatch();
-
   useEffect(() => {
     dispatch(getRockects());
   }, [dispatch]);
@@ -20,6 +19,8 @@ const Rockets = () => {
             name={rocket.rocket_name}
             description={rocket.description}
             image={rocket.flickr_images[1]}
+            reserved={rocket.reserved}
+            id={rocket.id}
           />
 
         ))}

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -13,7 +13,8 @@ export const getRockects = createAsyncThunk('rockets/getRockects',
   async (thunkAPI) => {
     try {
       const response = await axios(url);
-      return response.data;
+      const rocketsArray = response.data.map((rocket) => ({ ...rocket, reserved: false }));
+      return rocketsArray;
     } catch (error) {
       return thunkAPI.rejectWithValue('something went wrong');
     }
@@ -22,6 +23,16 @@ export const getRockects = createAsyncThunk('rockets/getRockects',
 const rocketsSlice = createSlice({
   name: 'rockets',
   initialState,
+  reducers: {
+    reservedRocket: (state, { payload }) => {
+      const newState = state.rockets.map((rocket) => {
+        if (rocket.id !== payload) { return rocket; }
+        return { ...rocket, reserved: !rocket.reserved };
+      });
+      return { ...state, rockets: newState };
+    },
+
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getRockects.pending, (state) => ({
@@ -37,4 +48,5 @@ const rocketsSlice = createSlice({
   },
 });
 
+export const { reservedRocket } = rocketsSlice.actions;
 export default rocketsSlice.reducer;

--- a/src/styles/rocket.scss
+++ b/src/styles/rocket.scss
@@ -43,3 +43,11 @@
   height: 30px;
   border-radius: 5px;
 }
+
+.reservation-status {
+  border: 1px solid;
+  border-radius: 6px;
+  padding: 0 5px;
+  color: #e6d5d5;
+  background-color: #7272c3;
+}


### PR DESCRIPTION
# Rockets actions: Implement rocket booking 🤓 
In this task I apply the next changes:
## Summary: 📖 
- When a user clicks the "Reserve rocket" button, action needs to be dispatched to update the store.
- Fix the #12 
- Follow the same logic as with the "Reserve rocket" - but you need to set the reserved key to false.
- Fix the #8  
- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design):
![reservations](https://user-images.githubusercontent.com/64999622/231257093-fe508c3a-421f-46da-845f-3a9ed5029a4d.gif)
- Fix the #5 


<img src="https://media2.giphy.com/media/qHlqtOUahoKz4jhC0v/giphy.gif"/>
