### PR TITLE
My profile: Refactoring and displaying multiple reserved sections

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,10 +1,22 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import RenderJoined from './renderJoined';
 
-const Profile = () => (
-  <>
-    <RenderJoined />
-  </>
-);
+const Profile = () => {
+  const reservedMission = useSelector((store) => store.mission.missions)
+    .filter((mission) => mission.reserved);
+  const reservedRockets = useSelector((store) => store.rockets.rockets)
+    .filter((rocket) => rocket.reserved);
+  return (
+    <ul className="reserved-sections">
+      <li className="section">
+        <RenderJoined list={reservedMission} render="missions" />
+      </li>
+      <li className="section">
+        <RenderJoined list={reservedRockets} render="rockets" />
+      </li>
+    </ul>
+  );
+};
 
 export default Profile;

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -7,8 +7,10 @@ const Rockets = () => {
   const { rockets } = useSelector((store) => store.rockets);
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(getRockects());
-  }, [dispatch]);
+    if (!rockets.length) {
+      dispatch(getRockects());
+    }
+  }, [dispatch, rockets]);
   return (
     <div>
       <div className="border-line"> </div>

--- a/src/components/renderJoined.jsx
+++ b/src/components/renderJoined.jsx
@@ -1,21 +1,59 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 
-const RenderJoined = () => {
-  const resrvedMission = useSelector((store) => store.mission.missions)
-    .filter((mission) => mission.reserved);
+const RenderJoined = ({ list, render }) => {
+  // eslint-disable-next-line consistent-return
+  const reservedRender = () => {
+    if (render === 'missions') {
+      return (
+
+        <>
+          <h2>My Missions</h2>
+          <div className="bookedMission">
+            {list.map((mission) => (
+              <p key={mission.mission_id} className="booked-element">
+                {mission.mission_name}
+              </p>
+            ))}
+          </div>
+
+        </>
+      );
+    } if (render === 'rockets') {
+      return (
+
+        <>
+          <h2>My Rockets</h2>
+          <div className="bookedMission">
+            {list.map((rocket) => (
+              <p key={rocket.id} className="booked-element">
+                {rocket.rocket_name}
+              </p>
+            ))}
+          </div>
+
+        </>
+      );
+    }
+    // Abraham add your return by defaul with your logic
+  };
   return (
     <section className="missions">
-      <h2>My Missions</h2>
-      <div className="bookedMission">
-        {resrvedMission.map((mission) => (
-          <p key={mission.mission_id} className="booked-element">
-            {mission.mission_name}
-          </p>
-        ))}
-      </div>
+      {reservedRender()}
     </section>
+
   );
+};
+
+RenderJoined.propTypes = {
+  list: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+  ]).isRequired,
+  render: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]).isRequired,
 };
 
 export default RenderJoined;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,11 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
-import rocketsSlice from './rockets/rocketsSlice';
+import rocketsReducer from './rockets/rocketsSlice';
 import missionReducer from './mission/missionSlice';
 import dragonReducer from './dragon/dragonSlice'; // Update to import dragonReducer instead of dragonSlice
 
 const store = configureStore({
   reducer: {
-    rockets: rocketsSlice,
+    rockets: rocketsReducer,
     mission: missionReducer,
     dragon: dragonReducer, // Update to include dragonReducer
   },

--- a/src/styles/mission.scss
+++ b/src/styles/mission.scss
@@ -80,3 +80,14 @@ table {
     }
   }
 }
+
+.reserved-sections {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+}
+
+.section {
+  width: 32%;
+}


### PR DESCRIPTION
# My profile: Refactoring and displaying multiple reserved sections 🤓 
In this task I apply the next changes:
## Summary: 📖 
- Refactor profile.jsx and renderJoined.jsx to make reusable for all the reserved sections in the app
- Fix the #3 
- Render a list of all reserved rockets (use filter()) on the "My profile" page: 
![reservations1](https://user-images.githubusercontent.com/64999622/231308688-a4f9d4ce-cb86-4125-9b15-359556af9801.gif)

<img src="https://media2.giphy.com/media/qHlqtOUahoKz4jhC0v/giphy.gif"/>


